### PR TITLE
[안희원-postpage] 비밀번호 기능 추가 & 더보기 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -46,7 +46,10 @@ function Card({ type, data = null, onCardClick }) {
           <Button type="trash" />
         </DeleteIcon>
       )}
-      <Content $font={font}>{content}</Content>
+      <ContentWrapper>
+        <Content $font={font}>{content}</Content>
+        <More>더보기</More>
+      </ContentWrapper>
       <Date>{formatDate(createdAt)}</Date>
     </Container>
   );
@@ -132,17 +135,15 @@ const DeleteIcon = styled.div`
 `;
 
 const Content = styled.div`
-  width: 100%;
-  height: 10.6rem;
+  height: 6rem;
 
   display: -webkit-box;
-  -webkit-line-clamp: 4;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 
   ${FONT18}
   color: var(--Gray6);
-  text-overflow: ellipsis;
   word-wrap: break-word;
   font-family: ${({ $font }) => $font};
   line-height: 155.556%;
@@ -161,4 +162,23 @@ const Date = styled.div`
 const PlusIcon = styled.div`
   width: 5.6rem;
   height: 5.6rem;
+`;
+
+const More = styled.div`
+  ${FONT12}
+  color: var(--Gray4);
+  text-align: right;
+
+  &:hover {
+    color: var(--Gray7);
+  }
+`;
+
+const ContentWrapper = styled.div`
+  width: 100%;
+  height: 10.6rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `;

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -88,6 +88,10 @@ const Container = styled.div`
   background-position: ${({ $url }) => ($url !== null ? null : `right bottom`)};
   box-shadow: 0 0.2rem 1.2rem 0px rgba(0, 0, 0, 0.08);
 
+  &:hover {
+    cursor: pointer;
+  }
+
   @media (max-width: ${DeviceSize.mobile}) {
     width: 20.8rem;
     height: 23.2rem;

--- a/src/components/InputModal.jsx
+++ b/src/components/InputModal.jsx
@@ -1,14 +1,26 @@
+import { useNavigate } from "react-router-dom";
 import { FONT18 } from "@/styles/FontStyles";
 import styled from "styled-components";
 import Input from "./commons/Input";
 import Button from "./commons/Button";
 
-function InputModal() {
+function InputModal({ password, onClose }) {
+  const navigate = useNavigate();
+
+  const handlePasswordCheck = (event) => {
+    const inputValue = event.target.children[1].children[0].value;
+    event.preventDefault();
+    if (inputValue == import.meta.env.VITE_EDIT_KEY || inputValue == password) {
+      onClose();
+      return navigate("/post/id/edit");
+    }
+  };
+
   return (
-    <Container>
-      <Text>비밀번호를 입력하세요.</Text>
+    <Container onSubmit={handlePasswordCheck}>
+      <Text>🔐 비밀번호를 입력하세요.</Text>
       <InputWrapper>
-        <Input />
+        <Input placeholder="●●●●" />
       </InputWrapper>
       <Button width="100" height="l" type="primary">
         확인
@@ -19,7 +31,7 @@ function InputModal() {
 
 export default InputModal;
 
-const Container = styled.div`
+const Container = styled.form`
   width: 36rem;
   padding: 4rem 4rem 3rem;
 

--- a/src/constants/test.js
+++ b/src/constants/test.js
@@ -22,11 +22,12 @@ export const MESSAGE2 = {
 
 export const RECIPIENT1 = {
   id: 2,
-  name: "강영훈",
+  name: "김나은",
   backgroundColor: "green",
   backgroundImageURL: null,
   createdAt: "2021-10-26T13:19:31.401765Z",
   messageCount: 11111111,
+  password: 1234,
   recentMessages: [
     {
       id: 32,
@@ -100,6 +101,7 @@ export const RECIPIENT2 = {
     "https://i.namu.wiki/i/eJhZH5b6Qg6Tbds1uk1PYRD4pkOZpSx0aefRNWiId7-Fwa7bYpAThZFMePZbD95s4T0IkXCAOvrAUumjDb-fSYhGbpuBk79iuaw7mfmXQwGtJ7UgTLTerVW_NzR7gP9q64I4qVYO4v5QcZBBsxCZGQ.webp",
   createdAt: "2023-10-26T13:19:31.401765Z",
   messageCount: 320,
+  password: 1234,
   recentMessages: [
     {
       id: 32,

--- a/src/pages/post/Layout.jsx
+++ b/src/pages/post/Layout.jsx
@@ -21,21 +21,21 @@ Layout.propTypes = {
 };
 
 function Layout({ path = "" }) {
-  const { backgroundColor, backgroundImageURL, messageCount, recentMessages } = RECIPIENT2;
+  const { backgroundColor, backgroundImageURL, messageCount, recentMessages, password } = RECIPIENT2;
   const sortedData = sortNew(recentMessages);
 
   return (
     <Background $color={backgroundColor} $url={backgroundImageURL}>
       {backgroundImageURL && <Mask></Mask>}
       <Container>
-        <Btn path={path} />
+        <Btn path={path} password={password} />
         <CardGrid path={path} messageCount={messageCount} recentMessages={sortedData} />
       </Container>
     </Background>
   );
 }
 
-function Btn({ path }) {
+function Btn({ path, password }) {
   const { isOpen, handleModalOpen, handleModalClose } = useModal();
   const windowWidth = useGetWindowWidth();
 
@@ -65,7 +65,7 @@ function Btn({ path }) {
       {isOpen && (
         <ModalPortal>
           <ModalFrame onClickClose={handleModalClose}>
-            <InputModal />
+            <InputModal password={password} onClose={handleModalClose} />
           </ModalFrame>
         </ModalPortal>
       )}


### PR DESCRIPTION
## Card 컴포넌트
- 더보기 기능 추가했습니다.
- 지금은 카드 전체를 눌러도 모달이 떠서 더보기에 hover 기능을 살리려면 **더보기를 클릭해야 모달이 뜨도록** 하는 게 좋을 것 같습니다! **변경할까요?**
<img width="311" alt="image" src="https://github.com/han-kimm/PART2-NDHH/assets/103186362/52b95103-1a36-4a06-9747-c5050e33387f">

## post/id 페이지
- 편집하기 버튼을 누르면 비밀번호 입력 모달이 뜨고
- **recipient 데이터에서 받아온 password**를 입력하거나
- **마스터 키**를 입력하면 (마스터키는 디코로 알려드릴게용 ><)
- post/id/edit 페이지로 이동합니다!

## 추가
- input 컴포넌트에 혹시 비밀번호 기능을 추가할 수 있을까요..?