### PR TITLE
feat (create, message): 키보드 웹 접근성 개선, 이미지 업로드 방식 추가, 화면 렌더링 애니메이션

### DIFF
--- a/src/components/commons/Editor.jsx
+++ b/src/components/commons/Editor.jsx
@@ -62,7 +62,6 @@ const Container = styled.div`
 
   .sun-editor,
   .se-container {
-    border: 0.1rem solid var(--Gray3);
     border-radius: 0.8rem;
   }
 

--- a/src/components/commons/Option.jsx
+++ b/src/components/commons/Option.jsx
@@ -1,15 +1,16 @@
-import PropTypes from "prop-types";
-import styled, { css } from "styled-components";
-import { FONT14, FONT14B, FONT16B, FONT18, FONT18B } from "@/styles/FontStyles";
 import CHECKIMG from "@/assets/check.svg";
 import PLUSIMG from "@/assets/plus_icon.svg";
-import { getURL } from "@/utils/getURL";
-import useModal from "@/hooks/useModal";
-import ModalPortal from "@/components/ModalPortal";
 import ModalFrame from "@/components/ModalFrame";
-import Input from "@/components/commons/Input";
+import ModalPortal from "@/components/ModalPortal";
 import Button from "@/components/commons/Button";
+import Input from "@/components/commons/Input";
+import useModal from "@/hooks/useModal";
+import { DeviceSize } from "@/styles/DeviceSize";
+import { FONT14, FONT14B, FONT18B } from "@/styles/FontStyles";
+import { getURL } from "@/utils/getURL";
+import PropTypes from "prop-types";
 import { useRef } from "react";
+import styled, { css, keyframes } from "styled-components";
 
 Option.propTypes = {
   color: PropTypes.oneOf(["orange", "purple", "blue", "green", "red"]),
@@ -94,14 +95,19 @@ function OptionImg({ check, setValue, img, setImgs, setSelected, ...props }) {
 function InputFile({ ...props }) {
   const input = useRef();
   const handleClick = (event) => {
-    if (event.key === "Enter" || event.key === " ") input.current.click();
+    console.log(event);
+    if (event.key === "Enter" || event.key === " " || event.type === "click") {
+      event.preventDefault();
+      input.current.click();
+      event.currentTarget.blur();
+    }
   };
 
   return (
     <>
-      <label tabIndex={0} htmlFor="file" onKeyUp={handleClick}>
+      <label tabIndex={0} htmlFor="file" onClick={handleClick} onKeyUp={handleClick}>
         <p>
-          <strong>파일</strong>
+          파일
           <br />
           추가하기
         </p>
@@ -121,9 +127,7 @@ function InputURL({ onSubmit, ...props }) {
     <>
       <label tabIndex={0} onClick={handleModalOpen} onKeyUp={handleClick}>
         <p>
-          <strong>URL</strong>
-          <br />
-          주소로
+          URL
           <br />
           추가하기
         </p>
@@ -181,8 +185,6 @@ const Container = styled.button`
 
   &:hover,
   &:focus-within {
-    opacity: 0.5;
-
     > img {
       display: none;
     }
@@ -196,7 +198,7 @@ const Container = styled.button`
 
     > label {
       width: 100%;
-      height: auto;
+      height: 100%;
 
       display: flex;
       flex-direction: column;
@@ -205,14 +207,15 @@ const Container = styled.button`
 
       cursor: pointer;
 
-      p {
-        ${FONT14}
+      &:hover,
+      &:focus {
+        p {
+          ${FONT14B};
+        }
       }
 
-      &:hover {
-        strong {
-          ${FONT16B};
-        }
+      p {
+        ${FONT14}
       }
     }
   }
@@ -225,8 +228,8 @@ const Container = styled.button`
       : `background-image: url(${src}); background-size: cover`};
 
   > div {
-    width: 4.4rem;
-    height: 4.4rem;
+    width: 20%;
+    height: 20%;
 
     border-radius: 10rem;
 
@@ -255,6 +258,13 @@ const Container = styled.button`
 
     position: absolute;
     overflow: hidden;
+  }
+
+  > img {
+    @media (max-width: ${DeviceSize.mobile}) {
+      width: 20%;
+      height: auto;
+    }
   }
 `;
 

--- a/src/pages/create/Layout.jsx
+++ b/src/pages/create/Layout.jsx
@@ -77,11 +77,11 @@ Options.propType = {
 };
 function Options({ selectedType, setValue }) {
   const [imgs, setImgs] = useState([]);
-  const [selectedOption, setSelectedOption] = useState(0);
+  const [selected, setSelected] = useState(0);
   const isColor = selectedType === SELECTED.color ? true : false;
 
   const handleOptionClick = (idx, item) => () => {
-    setSelectedOption(idx);
+    setSelected(idx);
     if (isColor) {
       const backgroundColor = item;
       setValue((prev) => ({ ...prev, backgroundColor, backgroundImageURL: null }));
@@ -92,16 +92,16 @@ function Options({ selectedType, setValue }) {
   };
 
   const option = isColor ? (
-    Object.values(COLOR).map((color, idx) => <Option key={idx} color={color} check={selectedOption === idx} onClick={handleOptionClick(idx, color)} />)
+    Object.values(COLOR).map((color, idx) => <Option key={idx} color={color} check={selected === idx} onClick={handleOptionClick(idx, color)} />)
   ) : (
     <>
-      <Option setValue={setValue} setImgs={setImgs} setSelected={setSelectedOption} />
-      {imgs && imgs.map((img, idx) => <Option key={idx} check={selectedOption === idx} img={img} onClick={handleOptionClick(idx, img)} />)}
+      <Option setValue={setValue} setImgs={setImgs} setSelected={setSelected} />
+      {imgs && imgs.map((img, idx) => <Option key={idx} check={selected === idx} img={img} onClick={handleOptionClick(idx, img)} />)}
     </>
   );
 
   useEffect(() => {
-    setSelectedOption(0);
+    setSelected(0);
   }, [selectedType]);
 
   return <Container__Options>{option}</Container__Options>;

--- a/src/pages/message/Layout.jsx
+++ b/src/pages/message/Layout.jsx
@@ -5,10 +5,13 @@ import TextEditor from "@/components/commons/Editor";
 import { Container, Submit, Title } from "@/components/instances/CreateMessage";
 import { REL } from "@/styles/ColorStyles";
 import { FONT12, FONT16, FONT24B } from "@/styles/FontStyles";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import styled, { keyframes } from "styled-components";
 import PLUSIMG from "@/assets/plus_icon.svg";
 import { getURL } from "@/utils/getURL";
+import ModalPortal from "@/components/ModalPortal";
+import ModalFrame from "@/components/ModalFrame";
+import Option from "@/components/commons/Option";
 
 const INITIAL = {
   sender: "",
@@ -81,51 +84,13 @@ function AddImg({ setValue, imgs, setImgs, selected, setSelected }) {
     setValue((prev) => ({ ...prev, profileImageURL }));
   };
 
-  const handleChange = (event) => {
-    const file = event.target.files[0];
-    if (file && file.size < 1024 ** 2 * 1) {
-      (async function (file) {
-        const profileImageURL = await getURL(file);
-        const thumbNailURL = URL.createObjectURL(file);
-        setSelected(0);
-        setImgs((prev) => [thumbNailURL, ...prev]);
-        setValue((prev) => ({ ...prev, profileImageURL }));
-      })(file);
-    }
-  };
-
   return (
     <Contents__addImg>
-      <InputAdd onChange={handleChange} />
+      <Option setValue={setValue} setImgs={setImgs} setSelected={setSelected} />
       {imgs.map((img, idx) => (
-        <button key={idx}>
-          <Img $src={img} alt={`${idx + 1}번째로 추가한 사진`} onClick={handleClick(idx, img)} $check={selected === idx} />
-          <CheckImg src={CHECKIMG} $check={selected === idx} />
-        </button>
+        <Option key={idx} alt={`${idx + 1}번째로 추가한 사진`} check={selected === idx} img={img} onClick={handleClick(idx, img)} />
       ))}
     </Contents__addImg>
-  );
-}
-
-function InputAdd({ ...props }) {
-  return (
-    <Contents__inputAdd>
-      <label htmlFor="file">
-        <img src={PLUSIMG} alt="이미지 추가하기" />
-        <span>
-          파일로
-          <br />
-          추가하기
-        </span>
-      </label>
-      <input id="file" type="file" accept="image/*" {...props} />
-      <div />
-      <span>
-        URL로
-        <br />
-        추가하기
-      </span>
-    </Contents__inputAdd>
   );
 }
 
@@ -167,29 +132,19 @@ const BaseContents = styled.div`
 
 const Contents__profileControl = styled.div`
   display: grid;
-  grid-template: auto auto / auto 100%;
+  grid-template: auto auto / auto 1fr;
   grid-template-areas:
     "img text"
     "img add";
   column-gap: 3.2rem;
 
-  p {
+  > p {
     margin-bottom: 1.2rem;
 
     ${FONT16};
     color: var(--Gray5);
 
     grid-area: text;
-  }
-
-  button {
-    width: 5.6rem;
-    height: 5.6rem;
-    margin-right: 0.4rem;
-    border-radius: 10rem;
-
-    display: inline-block;
-    position: relative;
   }
 `;
 
@@ -203,58 +158,6 @@ const ProfileImg = styled.div`
   ${({ $src }) => $src && `background-image: url(${$src}); background-size: cover;`}
 `;
 
-const Contents__addImg = styled.div`
-  grid-area: add;
-  display: flex;
-
-  label {
-    cursor: pointer;
-  }
-
-  span {
-    &:hover {
-      opacity: 0.5;
-    }
-  }
-
-  input[type="file"] {
-    width: 0;
-    height: 0;
-    padding: 0;
-    border: 0;
-
-    position: absolute;
-    overflow: hidden;
-    visibility: hidden;
-  }
-`;
-
-const Img = styled.div`
-  width: 5.6rem;
-  height: 5.6rem;
-  border-radius: 10rem;
-
-  cursor: pointer;
-
-  ${({ $check }) => $check && `opacity: 0.5;`}
-  ${({ $src }) => $src && `background-image: url(${$src}); background-size: cover;`}
-`;
-
-const CheckImg = styled.img`
-  padding: 0.5rem;
-  border-radius: 5rem;
-
-  display: ${({ $check }) => ($check ? `inline` : `none`)};
-
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
-  opacity: 0.7;
-  background-color: var(--Black);
-`;
-
 const fadeIn = keyframes`
   0% {
     opacity: 0;
@@ -264,41 +167,53 @@ const fadeIn = keyframes`
   }
 `;
 
-const Contents__inputAdd = styled.button`
-  &:hover {
-    width: 13rem;
+const Contents__addImg = styled.div`
+  grid-area: add;
+  display: flex;
+  align-items: center;
 
-    transition: width 0.5s ease-out;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
+  > button:first-child {
     background-color: var(--Gray5);
 
+    transition: 0.5s ease-in;
+
+    &:hover,
+    &:focus-within {
+      width: 15rem;
+      height: 5.6rem;
+
+      display: flex;
+      align-items: center;
+
+      background-color: var(--Gray2);
+
+      transition: 0.5s ease-out;
+
+      label {
+        animation: ${fadeIn} 1.5s;
+      }
+    }
+
     img {
-      display: none;
-    }
-
-    span {
-      display: inline-block;
-      animation: ${fadeIn} 1s ease-in;
-
-      color: var(--White);
-      ${FONT12}
-    }
-
-    div {
-      margin: 0 0.8rem;
-      height: 80%;
-
-      animation: ${fadeIn} 1s ease-in;
-
-      border-right: 0.1rem solid var(--Gray3);
+      width: 5.6rem;
     }
   }
 
-  span {
-    display: none;
+  > button {
+    width: 5.6rem;
+    height: 5.6rem;
+    margin-right: 0.4rem;
+
+    border: 0;
+    border-radius: 10rem;
+
+    &::after {
+      display: none;
+    }
+
+    div {
+      width: 60%;
+      height: 60%;
+    }
   }
 `;

--- a/src/styles/GlobalStyles.js
+++ b/src/styles/GlobalStyles.js
@@ -1,6 +1,15 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, keyframes } from 'styled-components';
 import reset from 'styled-reset';
 import { BLUE, GRAYSCALE, GREEN, MAIN, ORANGE, PURPLE, RED } from '@/styles/ColorStyles';
+
+const fadeIn = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
 
 const GlobalStyles = createGlobalStyle`
   :root {
@@ -25,20 +34,15 @@ const GlobalStyles = createGlobalStyle`
   }
 
   html, body, div, span, h1, h2, h3, h4, h5, h6, p, 
-  a, dl, dt, dd, ol, ul, li, form, label, table{
+  a, dl, dt, dd, ol, ul, li, form, label, table, button{
     margin: 0;
     padding: 0;
     border: 0;
     font-size: 62.5%;
     vertical-align: baseline;
+    animation: ${fadeIn} 0.5s ease-out;
   }
-
-  body{
-    line-height: 1;
-    font-family: 'Noto Sans KR', sans-serif;
-    background-color: #FFFFFF;
-  }
-
+  
   ol, ul{
     list-style: none;
   }
@@ -48,6 +52,35 @@ const GlobalStyles = createGlobalStyle`
     border: 0;
     background: transparent;
     cursor: pointer;
+  }
+
+  body{
+    line-height: 1;
+    font-family: 'Noto Sans KR', sans-serif;
+    background-color: #FFFFFF;
+
+    overflow-y: scroll;    
+  }
+    ::-webkit-scrollbar {
+    width: 14px;
+    height: 14px;
+}
+
+  ::-webkit-scrollbar-thumb {
+    outline: none;
+    border-radius: 10px;
+    border: 4px solid transparent;
+    box-shadow: inset 6px 6px 0 rgba(34, 34, 34, 0.15);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    border: 4px solid transparent;
+    box-shadow: inset 6px 6px 0 rgba(34, 34, 34, 0.3);
+  }
+
+  ::-webkit-scrollbar-track {
+    box-shadow: none;
+    background-color: transparent;
   }
 `;
 


### PR DESCRIPTION
> 프리뷰

![231111](https://github.com/han-kimm/PART2-NDHH/assets/78120157/0134cfb5-41b5-402f-9068-30b5a89030a9)

> 주요 변경 사항

-  배경, 프로필 이미지 **업로드 방식을 파일, URL로 구분**
-  transition, animation 넣어서 **부드럽게 화면 렌더링**하기
-  웹 접근성 요소 중에서 **키보드 접근성** 올리기

> 세부 변경 사항 
- [x]  배경, 프로필 이미지 **업로드 방식을 파일, URL로 구분**
1. - [x]  **Option 컴포넌트를 개조**해서 이미지 업로드가 가능한 Option 컴포넌트 생성
2. - [x] Create, Message 페이지에서 화면 구조에 맞게 CSS 스타일링
- [x]  transition, animation 넣어서 **부드럽게 화면 렌더링**하기
- [x]  웹 접근성 요소 중에서 **키보드 접근성** 올리기

    - [x]  HTML에서 keyboard focusable 태그(button 태그), tabIndex, autoFocus 사용하기
    - [x]  CSS에서 의사클래스 :hover와 :focus-within 함께 쓰기
    - [x]  JS에서 htmlElement.blur(), onKeyUp 등으로 키보드 관련 핸들러함수 만들기
1. - [ ] Editor 컴포넌트에서 키보드 접근성 올리기
    - [x] tab키가 들여쓰기 기능이어서 Ctrl 키 두 번 누르기로 focus가 넘어가게 만들기
    - [ ] toolbar에 키보드로 접근가능하게 만들기
   
2. - [x] Option 컴포넌트에서 키보드 접근성 올리기
    - [x] button 태그 내에서 button 태그 없애기 -> label 태그, tabIndex=0 사용함
    - [x] 흐름에 부자연스러운 태그는 tabIndex=-1 로 focus 없애기
    - [x] label 태그에 onKey[...] 이벤트 주기
    - [x] :hover 상황에서 키보드도 같은 이벤트 동작을 구현하기 위해서 :focus-within 사용
3. - [x] InputModal 컴포넌트에서 키보드 접근성 올리기
    - [x] tab focus 편의성을 위해 모달이 생성되었을 때, input 태그에 autoFocus 주기
    - [x] ModalFrame의 click하면 모달이 닫아지는 기능을 키보드에서도 사용할 수 있도록 focus 되면 화면이 닫아지도록 onFocus 이벤트 주기


> 느낀점
- 웹 접근성을 위한 길은 멀고도 멀다. 하지만, 늘 나의 편의는 누군가의 불편을 재료로 하고 있다는 사실을 기억해야 한다. 내가 그 불편을 나눠 가질 수 있지 않을까?
- Keyboadr focus 외에도 스크린리더에서 어떻게 읽히는지 생각해보면, 지금 사이트에서 alt 메시지를 수정할 필요가 있다. [지금 선택된 프로필 이미지], [2번째로 추가한 이미지]와 같이 동작이나 상태를 명확하게 보여주는 방식이 필요하다.