### PR TITLE
[김다은] 리팩토링

### DIFF
--- a/src/api/makePostData.js
+++ b/src/api/makePostData.js
@@ -21,13 +21,13 @@ export const makeMessage = ({ recipientId, sender, URL, relationship, content, f
     content,
     font,
   };
-}
+};
 
-export const makeEmoji = (emoji, type) => {
+export const makeEmoji = (emoji) => {
   return {
     postData: {
       emoji: emoji,
-      type: type,
+      type: "increase",
     },
   };
 };

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -48,7 +48,9 @@ function MakeServiceHeader({ userData }) {
         <Recipient>To. {userData.name}</Recipient>
         <Wrapper>
           <SendersNum>
-            <ProfileImgList messageCount={userData.messageCount} data={userData.recentMessages} />
+            <Contents messageCount={userData.messageCount}>
+              <ProfileImgList messageCount={userData.messageCount} data={userData.recentMessages} />
+            </Contents>
             <P $B>{userData.messageCount}</P>
             <P> 명이 작성했어요!</P>
             <DivideImg src={divideLine} alt="영역 분리 아이콘" />
@@ -124,6 +126,11 @@ const Wrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   grid-area: "Wrapper";
+`;
+
+const Contents = styled.div`
+  position: relative;
+  left: ${({ messageCount }) => (messageCount > 2 ? "1.4rem" : "4.5rem")};
 `;
 
 const ButtonText = styled.p`

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,23 +2,21 @@ import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 import { FONT14B, FONT16B, FONT16, FONT18, FONT18B, FONT28B } from "@/styles/FontStyles";
 import { DeviceSize } from "@/styles/DeviceSize";
-import { Recipients } from "@/constants/mockUp";
 import HeaderEmojis from "@/components/instances/HeaderEmoji";
 import ProfileImgList from "@/components/commons/ProfileImgList";
 import Button from "@/components/commons/Button";
 import Logo from "@/assets/Logo.svg";
 import divideLine from "@/assets/Rectangle_38.svg";
 import ShareDropdownButton from "./instances/ShareDropdownButton";
-import { Link, useParams } from "react-router-dom";
-import useGetData from "@/hooks/useGetData";
+import { Link } from "react-router-dom";
 
 Header.propTypes = {
   serviceType: PropTypes.oneOf([true, false]),
   hideButton: PropTypes.oneOf([true, false]),
 };
 
-function Header({ serviceType, hideButton = false }) {
-  return serviceType ? MakeServiceHeader() : MakeNavHeader({ hideButton });
+function Header({ serviceType, hideButton = false, userData }) {
+  return serviceType ? MakeServiceHeader({ userData }) : MakeNavHeader({ hideButton });
 }
 
 function MakeNavHeader({ hideButton }) {
@@ -41,10 +39,9 @@ function MakeNavHeader({ hideButton }) {
   );
 }
 
-function MakeServiceHeader() {
-  const { id } = useParams();
-  const userData = useGetData("RECIPIENTS_ID", "GET", id);
+function MakeServiceHeader({ userData }) {
   if (!userData) return;
+
   return (
     <>
       <Container>
@@ -58,7 +55,7 @@ function MakeServiceHeader() {
           </SendersNum>
           <HeaderEmojis topReactions={userData.topReactions} id={userData.id} />
           <DivideImg src={divideLine} alt="영역 분리 아이콘" />
-          <ShareDropdownButton />
+          <ShareDropdownButton id={userData.id} />
         </Wrapper>
       </Container>
       <BorderLine />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -41,11 +41,12 @@ function MakeNavHeader({ hideButton }) {
 
 function MakeServiceHeader({ userData }) {
   if (!userData) return;
+  const name = userData.name.slice(0, -4);
 
   return (
     <>
       <Container>
-        <Recipient>To. {userData.name}</Recipient>
+        <Recipient>To. {name}</Recipient>
         <Wrapper>
           <SendersNum>
             <Contents messageCount={userData.messageCount}>

--- a/src/components/instances/EmojiPickButton.jsx
+++ b/src/components/instances/EmojiPickButton.jsx
@@ -6,8 +6,9 @@ import { Z_INDEX } from "@/styles/ZindexStyles";
 import api from "@/api/api";
 import styled from "styled-components";
 import { DeviceSize } from "@/styles/DeviceSize";
+import { makeEmoji } from "@/api/makePostData";
 
-function EmojiPickButton({ id, setShouldRender }) {
+function EmojiPickButton({ id }) {
   const containerRef = useRef(null);
 
   const [isEmojiVisible, setIsEmojiVisible] = useState(false);
@@ -24,15 +25,12 @@ function EmojiPickButton({ id, setShouldRender }) {
 
   const onEmojiClick = async (event) => {
     const emojiSrc = event.emoji;
-
-    const postData = {
-      emoji: emojiSrc,
-      type: "increase",
-    };
+    const { postData } = makeEmoji(emojiSrc);
 
     const fetchResult = await api("RECIPIENTS_REACTIONS", "POST", id, postData);
+
     if (fetchResult) {
-      setShouldRender((prev) => prev++);
+      window.location.reload(true);
       setIsEmojiVisible(false);
     }
   };

--- a/src/components/instances/HeaderEmoji.jsx
+++ b/src/components/instances/HeaderEmoji.jsx
@@ -11,7 +11,6 @@ function HeaderEmojis({ topReactions, id }) {
   const containerRef = useRef(null);
 
   const [isVisible, setIsVisible] = useState(false);
-  const [shouldRender, setShouldRender] = useState(0);
 
   const endIndex = 7;
   if (topReactions.length > 8) topReactions = topReactions.slice(0, endIndex);
@@ -35,7 +34,7 @@ function HeaderEmojis({ topReactions, id }) {
         </button>
         {isVisible && <EmojiList results={topReactions} id={id} />}
       </Container>
-      <EmojiPickButton id={id} setShouldRender={setShouldRender} />
+      <EmojiPickButton id={id} />
     </>
   );
 }

--- a/src/components/instances/ShareDropdownButton.jsx
+++ b/src/components/instances/ShareDropdownButton.jsx
@@ -7,13 +7,14 @@ import { useRef, useState } from "react";
 import styled, { keyframes } from "styled-components";
 import Toast from "../commons/Toast";
 
-function ShareDropdownButton({ currentPath = "/" }) {
+function ShareDropdownButton({ id }) {
   const containerRef = useRef(null);
 
   const [isMenuVisible, setIsMenuVisible] = useState(false);
   const [isToastVisible, setIsToastVisible] = useState(false);
 
   const host = "http://localhost:5173";
+  const currentPath = `/post/${id}`;
 
   const copyClipboard = () => {
     navigator.clipboard
@@ -41,7 +42,7 @@ function ShareDropdownButton({ currentPath = "/" }) {
 
   return (
     <Container>
-      <ShareButton onBlur={handleBlur} ref={containerRef}>
+      <ShareButton onBlur={handleBlur}>
         <CustomButton type="outlined" width="56" height="m" onClick={handleClick}>
           <img src={shareIcon} alt="공유 버튼" />
         </CustomButton>
@@ -50,7 +51,7 @@ function ShareDropdownButton({ currentPath = "/" }) {
         </Wrapper>
       </ShareButton>
       {isMenuVisible && (
-        <List>
+        <List ref={containerRef}>
           <button onClick={() => shareKakaoTalk(host + currentPath)}>
             <Text>카카오톡 공유</Text>
           </button>
@@ -118,8 +119,8 @@ const Text = styled.li`
 const Wrapper = styled.div`
   position: fixed;
   left: 50%;
-  transform: translateX(-50%) translateY(${({ $isVisible }) => ($isVisible ? "2rem" : "-4rem")});
-  top: ${({ $isVisible }) => ($isVisible ? "2rem" : "-4rem")};
+  transform: translateX(-50%) translateY(${({ $isVisible }) => ($isVisible ? "8rem" : "-4rem")});
+  top: ${({ $isVisible }) => ($isVisible ? "8rem" : "-4rem")};
   z-index: ${Z_INDEX.Toast_Wrapper};
-  transition: 0.5s ease-in-out; // transform 지우기
+  transition: 0.5s ease-in-out;
 `;

--- a/src/hooks/useGetData.js
+++ b/src/hooks/useGetData.js
@@ -16,12 +16,12 @@ import { useState } from "react";
  *@returns {Object|null} - 가져온 데이터 또는 null (초기값)
  */
 
-function useGetData(type, method, path, limit) {
+function useGetData(type, path, limit) {
   const [data, setData] = useState();
 
   useEffect(() => {
     (async function () {
-      const result = await api(type, method, path, null, limit);
+      const result = await api(type, "GET", path, null, limit);
 
       if (["RECIPIENTS_ID", "BACKGROUND_IMGS", "PROFILE_IMGS", "MESSAGES"].includes(type)) return setData(result);
 

--- a/src/pages/list/Layout.jsx
+++ b/src/pages/list/Layout.jsx
@@ -8,7 +8,7 @@ import { Link } from "react-router-dom";
 import useGetData from "@/hooks/useGetData";
 
 function Layout() {
-  const Cards = useGetData("RECIPIENTS", "GET", null, 1000);
+  const Cards = useGetData("RECIPIENTS", null, 1000);
 
   if (Cards) {
     const NewestCards = sortNew([...Cards]);

--- a/src/pages/post/Layout.jsx
+++ b/src/pages/post/Layout.jsx
@@ -26,8 +26,8 @@ function Layout({ path = "" }) {
   const { id } = useParams();
   const navigate = useNavigate();
 
-  const recipientData = useGetData("RECIPIENTS_ID", "GET", id);
-  const messageData = useGetData("RECIPIENTS_MESSAGES", "GET", id);
+  const recipientData = useGetData("RECIPIENTS_ID", id);
+  const messageData = useGetData("RECIPIENTS_MESSAGES", id);
 
   if (path === "edit") {
     console.log(sessionStorage.getItem("editToken"));
@@ -47,7 +47,7 @@ function Layout({ path = "" }) {
 
   return (
     <>
-      <Header serviceType={true} />
+      <Header userData={recipientData} serviceType />
       <Background $color={backgroundColor} $url={backgroundImageURL}>
         {backgroundImageURL && <Mask></Mask>}
         <Container>

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -8,14 +8,9 @@ import { useParams } from "react-router";
 function PostPage({ page }) {
   const windowWidth = useGetWindowWidth();
 
-  const { id } = useParams();
-
-  const userData = useGetData("RECIPIENTS_ID", "GET", id);
-
   return (
     <>
       {windowWidth > DeviceSizeNum.mobile && <Header />}
-      <Header userData={userData} serviceType />
       <Layout path={page} />
     </>
   );

--- a/src/pages/post/PostPage.jsx
+++ b/src/pages/post/PostPage.jsx
@@ -2,13 +2,20 @@ import Header from "@/components/Header.jsx";
 import useGetWindowWidth from "@/hooks/useGetWindowWidth";
 import { DeviceSizeNum } from "@/styles/DeviceSize";
 import Layout from "./Layout";
+import useGetData from "@/hooks/useGetData";
+import { useParams } from "react-router";
 
 function PostPage({ page }) {
   const windowWidth = useGetWindowWidth();
 
+  const { id } = useParams();
+
+  const userData = useGetData("RECIPIENTS_ID", "GET", id);
+
   return (
     <>
       {windowWidth > DeviceSizeNum.mobile && <Header />}
+      <Header userData={userData} serviceType />
       <Layout path={page} />
     </>
   );


### PR DESCRIPTION
- 헤더 이모지 등록 시 새로고침 기능 추가
- post 페이지 헤더/서비스헤더 분리 + userData 페이지 컴포넌트에서 사용하도록 수정
-  링크 복사, 카카오톡 공유 시 현재 경로 사용
- 헤더 프로필 이미지 수에 따른 이미지 위치 변경